### PR TITLE
Fix/polish signup page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -15,7 +15,7 @@ import {
 import { doc, setDoc, getDoc } from "firebase/firestore";
 import { auth, db } from "@/lib/firebase";
 import { toast } from "react-toastify";
-import { InputWithIcon } from "@/components/ui/input";
+import { InputWithIcon } from "@/components/ui/input/input-with-icon";
 
 interface UserData {
   username: string;
@@ -117,7 +117,7 @@ export default function Login() {
         className="w-full max-w-md p-6 space-y-4 bg-card rounded-lg shadow-lg border"
       >
         <div className="text-center">
-          <h1 className="text-3xl font-bold">Login</h1>
+          <h1 className="text-3xl font-bold">Sign In</h1>
         </div>
 
         {error && (
@@ -126,7 +126,7 @@ export default function Login() {
           </div>
         )}
 
-        <form onSubmit={handleLogin} className="space-y-4">
+        <form onSubmit={handleLogin} className="space-y-2">
           <div className="space-y-1">
             <Label htmlFor="email">Email</Label>
             <InputWithIcon 
@@ -152,7 +152,7 @@ export default function Login() {
             />
           </div>
 
-          <Button type="submit" className="mt-20 w-full" size="lg">
+          <Button type="submit" className="!mt-4 w-full" size="lg">
             Sign In
           </Button>
         </form>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { motion } from "framer-motion";
 import Link from "next/link";
@@ -16,6 +15,7 @@ import {
 import { doc, setDoc, getDoc } from "firebase/firestore";
 import { auth, db } from "@/lib/firebase";
 import { toast } from "react-toastify";
+import { InputWithIcon } from "@/components/ui/input";
 
 interface UserData {
   username: string;
@@ -114,10 +114,10 @@ export default function Login() {
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.3 }}
-        className="w-full max-w-md p-8 space-y-6 bg-card rounded-lg shadow-lg border"
+        className="w-full max-w-md p-6 space-y-4 bg-card rounded-lg shadow-lg border"
       >
-        <div className="space-y-2 text-center">
-          <h1 className="text-3xl font-bold">Welcome</h1>
+        <div className="text-center">
+          <h1 className="text-3xl font-bold">Login</h1>
         </div>
 
         {error && (
@@ -127,9 +127,10 @@ export default function Login() {
         )}
 
         <form onSubmit={handleLogin} className="space-y-4">
-          <div className="space-y-2">
+          <div className="space-y-1">
             <Label htmlFor="email">Email</Label>
-            <Input 
+            <InputWithIcon 
+              icon="user"
               id="email" 
               type="email" 
               placeholder="user@example.com"
@@ -139,9 +140,10 @@ export default function Login() {
             />
           </div>
           
-          <div className="space-y-2">
+          <div className="space-y-1">
             <Label htmlFor="password">Password</Label>
-            <Input 
+            <InputWithIcon 
+              icon="key"
               id="password" 
               type="password"
               value={password}
@@ -150,14 +152,14 @@ export default function Login() {
             />
           </div>
 
-          <Button type="submit" className="w-full" size="lg">
+          <Button type="submit" className="mt-20 w-full" size="lg">
             Sign In
           </Button>
         </form>
 
         <div className="text-center text-sm">
           <Link href="/forgot-password" className="text-primary hover:underline">
-            Forgot your password?
+            <strong>Forgot your password?</strong> 
           </Link>
         </div>
 
@@ -190,7 +192,7 @@ export default function Login() {
         <p className="text-center text-sm">
           Don&apos;t have an account?{" "}
           <Link href="/register" className="text-primary hover:underline">
-            Sign up
+            <strong>Sign up</strong>
           </Link>
         </p>
       </motion.div>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { motion } from "framer-motion";
 import { useState } from "react";
@@ -16,6 +15,7 @@ import {
 import { getAuth } from "firebase/auth";
 import { firebaseApp } from "@/lib/firebase";
 import { useAuth } from "@/contexts/AuthContext";
+import { InputWithIcon } from "@/components/ui/input/input-with-icon";
 
 export default function Signup() {
   const [username, setUsername] = useState("");
@@ -63,10 +63,10 @@ export default function Signup() {
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.3 }}
-        className="w-full max-w-md p-8 space-y-6 bg-card rounded-lg shadow-lg border"
+        className="w-full max-w-md p-6 space-y-4 bg-card rounded-lg shadow-lg border"
       >
-        <div className="space-y-2 text-center">
-          <h1 className="text-3xl font-bold">Welcome</h1>
+        <div className="space-y-1 text-center">
+          <h1 className="text-3xl font-bold">Sign Up</h1>
         </div>
 
         {error && (
@@ -75,36 +75,37 @@ export default function Signup() {
           </div>
         )}
 
-        <form onSubmit={handleSignup} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="username" className="text-slate-700-font-mdeium">Username</Label>
-            <Input 
-              id="username" 
+        <form onSubmit={handleSignup} className="space-y-2">
+          <div className="space-y-1">
+            <Label htmlFor="username">Username</Label>
+            <InputWithIcon 
+              id="username"
+              icon="user" 
               type="text" 
               placeholder="Enter Username"
-              className="text-black placeholder:text-gray-500"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
             />
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="email" className="text-slate-700 font-medium">Email</Label>
-            <Input 
+          <div className="space-y-1">
+            <Label htmlFor="email">Email</Label>
+            <InputWithIcon
+              icon="message"
               id="email" 
               type="email" 
               placeholder="user@example.com"
-              className="text-black placeholder: text-gray-500"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
             />
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-1">
             <Label htmlFor="password">Password</Label>
-            <Input 
+            <InputWithIcon
+              icon="key"
               id="password" 
               type="password"
               value={password}
@@ -113,7 +114,7 @@ export default function Signup() {
             />
           </div>
 
-          <Button type="submit" className="w-full" size="lg">
+          <Button type="submit" className="!mt-4 w-full" size="lg">
             Sign Up
           </Button>
         </form>
@@ -123,7 +124,7 @@ export default function Signup() {
             href="/forgot-password"
             className="text-primary hover:underline"
           >
-            Forgot your password?
+            <strong>Forgot your password?</strong> 
           </Link>
         </div>
 
@@ -158,7 +159,7 @@ export default function Signup() {
         <p className="text-center text-sm">
           Have an account?{" "}
           <Link href="/login" className="text-primary hover:underline">
-            Log In
+            <strong>Log In</strong>
           </Link>
         </p>
       </motion.div>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -2,8 +2,56 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+type IconKey = "user" | "none" | "key";
+
+const icons: Record<IconKey, JSX.Element | string> = {
+  user: (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" className="size-6">
+      <path fillRule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clipRule="evenodd" />
+    </svg>
+  ),
+  key:<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-6">
+  <path fillRule="evenodd" d="M15.75 1.5a6.75 6.75 0 0 0-6.651 7.906c.067.39-.032.717-.221.906l-6.5 6.499a3 3 0 0 0-.878 2.121v2.818c0 .414.336.75.75.75H6a.75.75 0 0 0 .75-.75v-1.5h1.5A.75.75 0 0 0 9 19.5V18h1.5a.75.75 0 0 0 .53-.22l2.658-2.658c.19-.189.517-.288.906-.22A6.75 6.75 0 1 0 15.75 1.5Zm0 3a.75.75 0 0 0 0 1.5A2.25 2.25 0 0 1 18 8.25a.75.75 0 0 0 1.5 0 3.75 3.75 0 0 0-3.75-3.75Z" clipRule="evenodd" />
+</svg>,
+  none:""
+};
+
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+interface InputWithIconProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  icon: IconKey;
+}
+
+const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIconProps>(
+  ({ className, type, icon = "none", ...props }, ref) => {
+    return (
+      <div
+        className={cn(
+          "group flex items-center gap-1 h-10 w-full rounded-md border border-input bg-background p-2 text-sm ring-offset-background",
+          "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+          "transition-colors",
+        )}
+      >
+        {icon !== "none" && (
+          <div className="w-5 h-5 flex items-center pointer-events-none text-muted-foreground">
+            {icons[icon]}
+          </div>
+        )}
+        <input
+          type={type}
+          className={cn(
+            "flex w-full bg-transparent outline-none text-sm", // <-- bg transparente no input
+            className
+          )}
+          ref={ref}
+          {...props}
+        />
+      </div>
+    );
+  }
+);
+
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
@@ -22,4 +70,4 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 Input.displayName = 'Input';
 
-export { Input };
+export { Input, InputWithIcon };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -2,56 +2,8 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-type IconKey = "user" | "none" | "key";
-
-const icons: Record<IconKey, JSX.Element | string> = {
-  user: (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" className="size-6">
-      <path fillRule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clipRule="evenodd" />
-    </svg>
-  ),
-  key:<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-6">
-  <path fillRule="evenodd" d="M15.75 1.5a6.75 6.75 0 0 0-6.651 7.906c.067.39-.032.717-.221.906l-6.5 6.499a3 3 0 0 0-.878 2.121v2.818c0 .414.336.75.75.75H6a.75.75 0 0 0 .75-.75v-1.5h1.5A.75.75 0 0 0 9 19.5V18h1.5a.75.75 0 0 0 .53-.22l2.658-2.658c.19-.189.517-.288.906-.22A6.75 6.75 0 1 0 15.75 1.5Zm0 3a.75.75 0 0 0 0 1.5A2.25 2.25 0 0 1 18 8.25a.75.75 0 0 0 1.5 0 3.75 3.75 0 0 0-3.75-3.75Z" clipRule="evenodd" />
-</svg>,
-  none:""
-};
-
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
-
-interface InputWithIconProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  icon: IconKey;
-}
-
-const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIconProps>(
-  ({ className, type, icon = "none", ...props }, ref) => {
-    return (
-      <div
-        className={cn(
-          "group flex items-center gap-1 h-10 w-full rounded-md border border-input bg-background p-2 text-sm ring-offset-background",
-          "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
-          "transition-colors",
-        )}
-      >
-        {icon !== "none" && (
-          <div className="w-5 h-5 flex items-center pointer-events-none text-muted-foreground">
-            {icons[icon]}
-          </div>
-        )}
-        <input
-          type={type}
-          className={cn(
-            "flex w-full bg-transparent outline-none text-sm", // <-- bg transparente no input
-            className
-          )}
-          ref={ref}
-          {...props}
-        />
-      </div>
-    );
-  }
-);
-
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
@@ -70,4 +22,4 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 Input.displayName = 'Input';
 
-export { Input, InputWithIcon };
+export { Input };

--- a/components/ui/input/icons.tsx
+++ b/components/ui/input/icons.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+export const icons = {
+  user: (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" className="size-6">
+      <path fillRule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clipRule="evenodd" />
+    </svg>
+  ),
+  key: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-6">
+      <path fillRule="evenodd" d="M15.75 1.5a6.75 6.75 0 0 0-6.651 7.906c.067.39-.032.717-.221.906l-6.5 6.499a3 3 0 0 0-.878 2.121v2.818c0 .414.336.75.75.75H6a.75.75 0 0 0 .75-.75v-1.5h1.5A.75.75 0 0 0 9 19.5V18h1.5a.75.75 0 0 0 .53-.22l2.658-2.658c.19-.189.517-.288.906-.22A6.75 6.75 0 1 0 15.75 1.5Zm0 3a.75.75 0 0 0 0 1.5A2.25 2.25 0 0 1 18 8.25a.75.75 0 0 0 1.5 0 3.75 3.75 0 0 0-3.75-3.75Z" clipRule="evenodd" />
+    </svg>
+  ),
+  message: (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-6">
+      <path d="M1.5 8.67v8.58a3 3 0 0 0 3 3h15a3 3 0 0 0 3-3V8.67l-8.928 5.493a3 3 0 0 1-3.144 0L1.5 8.67Z" />
+      <path d="M22.5 6.908V6.75a3 3 0 0 0-3-3h-15a3 3 0 0 0-3 3v.158l9.714 5.978a1.5 1.5 0 0 0 1.572 0L22.5 6.908Z" />
+    </svg>
+  ),
+  none: null,
+} as const;
+
+export type IconKey = keyof typeof icons;

--- a/components/ui/input/input-with-icon.tsx
+++ b/components/ui/input/input-with-icon.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { icons, IconKey } from "./icons";
+
+interface InputWithIconProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  icon: IconKey;
+}
+
+export const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIconProps>(
+  ({ className, type, icon = "none", ...props }, ref) => {
+    return (
+      <div
+        className={cn(
+          "group flex items-center gap-1 h-10 w-full rounded-md border border-input bg-background p-2 text-sm ring-offset-background",
+          "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+          "transition-colors"
+        )}
+      >
+        {icon !== "none" && (
+          <div className="w-5 h-5 flex items-center pointer-events-none text-muted-foreground">
+            {icons[icon]}
+          </div>
+        )}
+        <input
+          type={type}
+          className={cn(
+            "flex w-full bg-transparent outline-none text-sm text-foreground",
+            className
+          )}
+          ref={ref}
+          {...props}
+        />
+      </div>
+    );
+  }
+);
+InputWithIcon.displayName = "InputWithIcon";


### PR DESCRIPTION
This PR introduces the `InputWithIcon` component and normalizes the layout of the Login and Register pages to ensure visual consistency. Fix #44 

- **`InputWithIcon` component**
  - Accepts an icon (`user`, `key`, `message`, or `none`)

- **UI normalization**
  - Standardized spacing (`gap`, `padding`, `margin`) between form elements across **Login** and **Register** pages
  - Consistent layout structure using `space-y`, `p-6`, `sm:p-8`, `max-w-md`, etc.
  - Error messages and links aligned and styled consistently
  - Some bugs on register form (like wrong text colors or font weight)

*obs: I temporarily disabled authentication since I don't have a valid API key, which was preventing me from testing. Despite that, I was able to complete the implementation. If anything is broken as a result, please let me know.*

### 📸 Screenshots
![signin](https://github.com/user-attachments/assets/77124965-4a47-404e-8170-2de989bf49a5)
![signup](https://github.com/user-attachments/assets/af8d77ab-edeb-4f04-871d-65c7b805caa6)
