### PR TITLE
Fixed overlapping buttons in about component

### DIFF
--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -64,15 +64,14 @@ export function Navbar() {
                   <Briefcase className="h-6 w-6 text-white" />
                 </div>
               </div>
-              <span className="font-bold text-2xl text-white group-hover:text-gray-200 transition-colors duration-300">
+              <span className="font-bold text-2xl text-white group-hover:text-gray-200 transition-colors duration-300 leading none">
                 Fail U Forward
               </span>
             </Link>
           </motion.div>
         </div>
-
         {/* Right side controls (Desktop) */}
-        <div className="hidden md:flex items-center space-x-4">
+        <div className="hidden md:flex items-center gap-3 justify-center w-full bg-transparent">
           {loggedIn ? (
             <div className="flex items-center space-x-2">
               <DropdownMenu>


### PR DESCRIPTION


Fixed # 254
## Checklist
- [yes] I have performed a self-review of my code  
- [yes ] I have commented my code, particularly in hard-to-understand areas  
- [yes ] I have updated the documentation where applicable  
- [yes ] My changes do not break existing functionality  

## Screenshots (if applicable)
## before changes: the overlapping buttons:
<img width="1880" height="403" alt="Screenshot 2025-11-03 150916" src="https://github.com/user-attachments/assets/9e5f379e-9ac8-455c-966a-25eee2607dd0" />

## after changes:
<img width="1881" height="410" alt="Screenshot 2025-11-03 151021" src="https://github.com/user-attachments/assets/d53c01a8-0245-420b-9eba-84b8e79b3dc7" />



